### PR TITLE
Gmail requires action endpoint to return 200 ok

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,3 +296,6 @@ DEPENDENCIES
   twilio-ruby
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.2

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -84,7 +84,7 @@ class IncidentsController < ApplicationController
     @incident.acknowledge!
     respond_to do |format|
       format.html { redirect_to incidents_url, notice: 'Incident was successfully acknowledged.' }
-      format.json { head :no_content }
+      format.json { render json: {status: 'ok'} }
     end
   end
 
@@ -92,7 +92,7 @@ class IncidentsController < ApplicationController
     @incident.resolve!
     respond_to do |format|
       format.html { redirect_to incidents_url, notice: 'Incident was successfully resolved.' }
-      format.json { head :no_content }
+      format.json { render json: {status: 'ok'} }
     end
   end
 

--- a/app/views/notifier_providers/mailgun/default.html.erb
+++ b/app/views/notifier_providers/mailgun/default.html.erb
@@ -8,6 +8,7 @@
   <body>
     <%
       ack_url = Rails.application.routes.url_helpers.acknowledge_incident_url(event.incident, hash: event.incident.confirmation_hash)
+      ack_url_json = Rails.application.routes.url_helpers.acknowledge_incident_url(event.incident, hash: event.incident.confirmation_hash, format: :json)
       resolve_url = Rails.application.routes.url_helpers.resolve_incident_url(event.incident, hash: event.incident.confirmation_hash)
 
       email_markup = {
@@ -18,7 +19,7 @@
           "name" => "Acknowledge incident",
           "handler" => {
             "@type" => "HttpActionHandler",
-            "url" => ack_url,
+            "url" => ack_url_json,
           },
         },
         "description" => "Acknowledge incident: #{event.incident.subject}",


### PR DESCRIPTION
Fixup #19 

https://developers.google.com/gmail/markup/actions/handling-action-requests#returning_a_response_code

> Once the service processed and recorded the action successfully, it should return a response code `200 (OK)`.

- `IncidentsController`: Change JSON format response to return 200 OK
- `notifier_providers/mailgun/default.html.erb`: Use JSON format endpoint
  for action handler URL