### PR TITLE
Include description in Slack Notify

### DIFF
--- a/app/models/notifier_provider.rb
+++ b/app/models/notifier_provider.rb
@@ -311,6 +311,13 @@ class NotifierProvider < ActiveRecord::Base
         color = 'danger'
         title = 'New incident opened'
         action_links = "<#{acknowledge_url}|Acknowledge> or <#{resolve_url}|Resolve> | <#{comment_url}|Comment>"
+
+        if include_description
+          fields << {
+            "title" => "Description",
+            "value" => @event.incident.description,
+          }
+        end
       when :acknowledged
         color = 'warning'
         title = 'Incident acknowledged'
@@ -367,6 +374,10 @@ class NotifierProvider < ActiveRecord::Base
 
     def target_events
       [:escalated, :opened, :acknowledged, :resolved]
+    end
+
+    def include_description
+      settings['include_description']
     end
   end
 


### PR DESCRIPTION
Include mail description in Slack Notify when `include_description: true`.

Please merge if no problem 🙇 
![20161028101855_img20161028-9-c01xpr](https://cloud.githubusercontent.com/assets/117768/19803446/b18daf48-9d43-11e6-9b65-e5d3d70bab6d.png)
