### PR TITLE
Fix fail user create with calendar scope

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   config[:hd] = ENV['GOOGLE_DOMAIN'] if ENV['GOOGLE_DOMAIN']
 
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
-    config.merge(scope: 'profile,userinfo.email,calendar', name: 'google_oauth2_with_calendar')
+    config.merge(scope: 'profile,userinfo.email,calendar', prompt: 'consent', name: 'google_oauth2_with_calendar')
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], config
 end
 OmniAuth.config.logger = Rails.logger

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   config[:hd] = ENV['GOOGLE_DOMAIN'] if ENV['GOOGLE_DOMAIN']
 
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
-    config.merge(scope: 'userinfo.email,calendar', name: 'google_oauth2_with_calendar')
+    config.merge(scope: 'profile,userinfo.email,calendar', name: 'google_oauth2_with_calendar')
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], config
 end
 OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
### Fix fail user create with calendar scope
When authenticate from `/auth/google_oauth2_with_calendar/`, user registration will fail.
The reason is that the name is empty because the profile scope is insufficient.

Add `profile` scope to `google_oauth2_with_calendar` provider.

The default for omniauth is `profile,email`, so the `google_ oauth2` provider seems to be okay.

### Fix lost refresh_token
When access the `/auth/google_oauth2_with_calendar/` with the user already created, refresh_token lost.

Add `prompt: 'consent'` option to `google_oauth2_with_calendar` provider.

This change ensures that refresh_token is issued at the time of authentication.

please merge, if this is no problem.