### PR TITLE
AlertManagerのURLを表示する

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,6 @@
 class TopicsController < ApplicationController
-  before_action :set_topic, only: [:show, :edit, :update, :destroy, :mailgun, :mackerel]
-  skip_before_action :login_required, only: [:mailgun, :mackerel]
+  before_action :set_topic, only: [:show, :edit, :update, :destroy, :mailgun, :mackerel, :alertmanager]
+  skip_before_action :login_required, only: [:mailgun, :mackerel, :alertmanager]
 
   # GET /topics
   # GET /topics.json

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -29,5 +29,10 @@
   <pre><%= mackerel_topic_url(@topic, format: :json) %></pre>
 </p>
 
+<p>
+  <strong>AlertManagerEndpoint:</strong>
+  <pre><%= alertmanager_topic_url(@topic, format: :json) %></pre>
+</p>
+
 <%= link_to 'Edit', edit_topic_path(@topic) %> |
 <%= link_to 'Back', topics_path %>


### PR DESCRIPTION
こんにちは！ペパボでもwakerをとても便利に利用させていただいています。AlertManagerのtopic表示時にURLが出ていなかったので追加しました。


