### PR TITLE
Enhance mackerel

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -98,7 +98,8 @@ class TopicsController < ApplicationController
       return
     end
 
-    subject = "[" + data['alert']['status'] + "] " + data['host']['name']
+    name = data.key?('host') ?  data['host']['name'] : data['alert']['monitorName']
+    subject = "[" + data['alert']['status'] + "] " + name
     description = JSON.pretty_generate(data)
 
     if @topic.in_maintenance?(subject, description)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -91,6 +91,7 @@ class TopicsController < ApplicationController
   # POST /topics/1/mackerel
   def mackerel
     data = JSON.parse(request.body.read)
+    return  render json: {}, status: 200 if data['alert']['status'] == 'ok'
 
     unless @topic.enabled
       Rails.logger.info "Incident creation is skipped because the topic is disabled."


### PR DESCRIPTION
このPRを取り込むと下記の実装が追加されます。

1. mackerelの外形監視通知が正常にトピック登録されるようになる
2. mackerelでアラート復旧時に余計なエスカレーションが発生しなくなる

@hfm