### PR TITLE
We now get refresh token

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   config[:hd] = ENV['GOOGLE_DOMAIN'] if ENV['GOOGLE_DOMAIN']
 
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
-    config.merge(scope: 'userinfo.email,calendar', name: 'google_oauth2_with_calendar')
-  provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], config
+  config.merge(scope: 'userinfo.profile,userinfo.email,calendar',
+               name: 'google_oauth2_with_calendar',
+               access_type: 'offline', approval_prompt: 'force', prompt: 'consent')
 end
 OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
refs: https://github.com/zquestz/omniauth-google-oauth2/issues/27

omniauthの認証時にrefresh tokenが取得できずにカレンダーに基づいたエスカレ順序の変更が出来なくなっていたので、omniauthの設定をかえることで、refresh tokenを取得するようにしました。