### PR TITLE
Support mackerel alert group notifications

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -100,10 +100,10 @@ class TopicsController < ApplicationController
     end
 
     if data['event'] == 'alertGroup' then
-      subject = "[" + data['alertGroup']['status'] + "] " + data['alertGroupSetting']['name']
+      subject = "[#{data['alertGroup']['status']}] #{data['alertGroupSetting']['name']}"
     else
       name = data.key?('host') ?  data['host']['name'] : data['alert']['monitorName']
-      subject = "[" + data['alert']['status'] + "] " + name
+      subject = "[#{data['alert']['status']}] #{name}"
     end
     description = JSON.pretty_generate(data)
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -91,7 +91,7 @@ class TopicsController < ApplicationController
   # POST /topics/1/mackerel
   def mackerel
     data = JSON.parse(request.body.read)
-    return  render json: {}, status: 200 if data['alert']['status'] == 'ok'
+    return  render json: {}, status: 200 if data.dig('alert', 'status') == 'ok' || data.dig('alertGroup', 'status') == 'ok'
 
     unless @topic.enabled
       Rails.logger.info "Incident creation is skipped because the topic is disabled."

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -99,8 +99,12 @@ class TopicsController < ApplicationController
       return
     end
 
-    name = data.key?('host') ?  data['host']['name'] : data['alert']['monitorName']
-    subject = "[" + data['alert']['status'] + "] " + name
+    if data['event'] == 'alertGroup' then
+      subject = "[" + data['alertGroup']['status'] + "] " + data['alertGroupSetting']['name']
+    else
+      name = data.key?('host') ?  data['host']['name'] : data['alert']['monitorName']
+      subject = "[" + data['alert']['status'] + "] " + name
+    end
     description = JSON.pretty_generate(data)
 
     if @topic.in_maintenance?(subject, description)


### PR DESCRIPTION
Alert group notifications differ from conventional alert notifications in format.
This PR will support incident creation by alert group notification.

Payload is as follows. 
This is an example of a payload given by the mackerel support team. ( not documented yet )
```
{
  "alertGroupSetting": {
    "memo": "this is memo text.",
    "name": "setting name of alert group",
    "url": "https://mackerel.io/orgs/.../alert-group-settings/3q2vU...",
    "id": "3q2vU..."
  },
  "alertGroup": {
    "closedAt": null,
    "createdAt": 1536806346,
    "status": "CRITICAL",
    "url": "https://mackerel.io/orgs/.../alert-groups/3q2wm...",
    "id": "3q2wm..."
  },
  "event": "alertGroup",
  "orgName": "..."
}
```

ref: https://mackerel.io/docs/entry/howto/alert-groups