### PR TITLE
Couldn't use UTF-8 in docker-compose environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - 5000:5000
     environment:
-      DATABASE_URL: 'mysql2://database/waker_development'
+      DATABASE_URL: 'mysql2://database/waker_development?encoding=utf8mb4&collation=utf8mb4_unicode_ci'
       REDIS_HOST: cache
     depends_on:
       - database


### PR DESCRIPTION
I am using the docker-compose environment conveniently for development. Thank you very much.

I made this PR because I was in trouble because register failed incident including Japanese.