### PR TITLE
Fix IncidentEventsController#twilio Fatal error

### DIFF
--- a/app/controllers/incident_events_controller.rb
+++ b/app/controllers/incident_events_controller.rb
@@ -16,8 +16,8 @@ class IncidentEventsController < ApplicationController
         @event.incident.resolve! rescue nil
       end
       resp = Twilio::TwiML::VoiceResponse.new do |r|
-        r.Say @event.incident.status, voice: 'alice', language: language
-        r.Hangup
+        r.say message: @event.incident.status, voice: 'alice', language: language
+        r.hangup
       end
     else
       resp = Twilio::TwiML::VoiceResponse.new do |r|

--- a/app/controllers/incident_events_controller.rb
+++ b/app/controllers/incident_events_controller.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
 class IncidentEventsController < ApplicationController
-  skip_before_action :login_required, only: [:twilio]
+  skip_before_action :login_required, only: [:twilio], raise: false
 
   def twilio
     @event = IncidentEvent.find(params[:id])

--- a/spec/factories/incident.rb
+++ b/spec/factories/incident.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :incident do
+    id { 1 }
     topic
     subject { "mysql-01 is down" }
     description { "alert" }

--- a/spec/factories/incident_events.rb
+++ b/spec/factories/incident_events.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :incident_event do
+    incident_id { 1 }
+    kind { :opened }
+  end
+end

--- a/spec/requests/incident_envets_spec.rb
+++ b/spec/requests/incident_envets_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe "IncidentEvent", type: :request do
+  describe "POST /incident_events/:id/twilio" do
+    let(:incident) { create(:incident) }
+    let(:event) { create(:incident_event, incident_id: incident.id) }
+
+    describe 'without params[:Digits]' do
+      it "works!" do
+        post "/incident_events/#{event.id}/twilio"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'with params[:Digits]' do
+      before do
+        post "/incident_events/#{event.id}/twilio", params: { Digits: digit}
+        incident.reload
+      end
+
+      context '1' do
+        let(:digit) { 1 }
+        it "acknowledged" do
+          expect(response).to have_http_status(200)
+          expect(incident.status).to eq 'acknowledged'
+        end
+      end
+
+      context '2' do
+        let(:digit) { 2 }
+        it "resolved" do
+          expect(response).to have_http_status(200)
+          expect(incident.status).to eq 'resolved'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed Fatal error in `IncidentEventsController#twilio`.
It happens when respond to an escalation call from Twilio.

```
[2020-06-17T09:04:10.246871 #6]  INFO -- : Started POST ""/incident_events/68015/twilio?AccountSid=...
[2020-06-17T09:04:10.248879 #6]  INFO -- : Processing by IncidentEventsController#twilio as HTML"
[2020-06-17T09:04:10.249305 #6]  INFO -- :   Parameters: { ... ""Digits""=>""1" ... }"
[2020-06-17T09:04:10.249827 #6]  WARN -- : Can't verify CSRF token authenticity."
[2020-06-17T09:04:10.335543 #6] FATAL -- :"
[2020-06-17T09:04:10.335692 #6] FATAL -- : NoMethodError (undefined method `Say' for #<Twilio::TwiML::VoiceResponse:0x00007efcd044dc88>):"
[2020-06-17T09:04:10.335755 #6] FATAL -- :"
[2020-06-17T09:04:10.335796 #6] FATAL -- : app/controllers/incident_events_controller.rb:19:in `block in twilio'"
```